### PR TITLE
Inventory layering & interaction tweak

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -197,8 +197,9 @@ What is the naming convention for planes or layers?
 #define HUD_PLANE                     9001 // For the Head-Up Display
 	#define UNDER_HUD_LAYER      0
 	#define HUD_BASE_LAYER       1
-	#define HUD_ITEM_LAYER       2
-	#define HUD_ABOVE_ITEM_LAYER 3
+	#define HUD_CLICKABLE_LAYER  2
+	#define HUD_ITEM_LAYER       3
+	#define HUD_ABOVE_ITEM_LAYER 4
 
 #define ABOVE_HUD_PLANE               9002 // For things to appear over the HUD
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -84,9 +84,7 @@
 	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return 1
 	if(master)
-		var/obj/item/I = usr.get_active_hand()
-		if(I)
-			usr.ClickOn(master)
+		usr.ClickOn(master)]
 	return 1
 
 /obj/screen/zone_sel

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -84,7 +84,7 @@
 	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return 1
 	if(master)
-		usr.ClickOn(master)]
+		usr.ClickOn(master)
 	return 1
 
 /obj/screen/zone_sel

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -8,6 +8,9 @@
 	var/obj/screen/storage/stored_start
 	var/obj/screen/storage/stored_continue
 	var/obj/screen/storage/stored_end
+
+	var/list/obj/screen/storage/containers
+
 	var/obj/screen/close/closer
 
 /datum/storage_ui/default/New(var/storage)
@@ -40,13 +43,21 @@
 
 	stored_start = new /obj //we just need these to hold the icon
 	stored_start.icon_state = "stored_start"
-	stored_start.layer = HUD_BASE_LAYER
+	stored_start.mouse_opacity = 1
+	stored_start.plane = FLOAT_PLANE
+	stored_start.layer = HUD_CLICKABLE_LAYER
 	stored_continue = new /obj
 	stored_continue.icon_state = "stored_continue"
-	stored_continue.layer = HUD_BASE_LAYER
+	stored_continue.mouse_opacity = 1
+	stored_continue.plane = FLOAT_PLANE
+	stored_continue.layer = HUD_CLICKABLE_LAYER
 	stored_end = new /obj
 	stored_end.icon_state = "stored_end"
-	stored_end.layer = HUD_BASE_LAYER
+	stored_end.mouse_opacity = 1
+	stored_end.plane = FLOAT_PLANE
+	stored_end.layer = HUD_CLICKABLE_LAYER
+
+	containers = list()
 
 	closer = new /obj/screen/close(  )
 	closer.master = storage
@@ -62,6 +73,7 @@
 	QDEL_NULL(stored_start)
 	QDEL_NULL(stored_continue)
 	QDEL_NULL(stored_end)
+	QDEL_NULL_LIST(containers)
 	QDEL_NULL(closer)
 	. = ..()
 
@@ -102,9 +114,12 @@
 	user.client.screen -= storage_start
 	user.client.screen -= storage_continue
 	user.client.screen -= storage_end
+	user.client.screen -= containers
 	user.client.screen -= closer
 	user.client.screen -= storage.contents
+
 	user.client.screen += closer
+	user.client.screen += containers
 	user.client.screen += storage.contents
 	if(storage.storage_slots)
 		user.client.screen += boxes
@@ -124,6 +139,7 @@
 	user.client.screen -= storage_continue
 	user.client.screen -= storage_end
 	user.client.screen -= closer
+	user.client.screen -= containers
 	user.client.screen -= storage.contents
 	if(user.s_active == storage)
 		user.s_active = null
@@ -131,6 +147,14 @@
 //Creates the storage UI
 /datum/storage_ui/default/prepare_ui()
 	//if storage slots is null then use the storage space UI, otherwise use the slots UI
+	for (var/mob/user in is_seeing)
+		if(user)
+			user.client.screen -= containers
+	for (var/container in containers)
+		if(container)
+			qdel(container)
+	containers.Cut()
+
 	if(storage.storage_slots == null)
 		space_orient_objs()
 	else
@@ -182,6 +206,15 @@
 	boxes.screen_loc = "4:16,2:16 to [4+cols]:16,[2+rows]:16"
 
 	for(var/obj/O in storage.contents)
+		var/obj/screen/storage/box = new()
+		box.SetName(O.name)
+		box.master = O
+		box.icon_state = "block"
+		box.screen_loc = "[cx]:16,[cy]:16"
+		box.layer = HUD_CLICKABLE_LAYER
+
+		containers += box
+
 		O.screen_loc = "[cx]:16,[cy]:16"
 		O.maptext = ""
 		O.hud_layerise()
@@ -198,8 +231,6 @@
 	var/storage_cap_width = 2 //length of sprite for start and end of the box representing total storage space
 	var/stored_cap_width = 4 //length of sprite for start and end of the box representing the stored item
 	var/storage_width = min( round( 224 * storage.max_storage_space/baseline_max_storage_space ,1) ,284) //length of sprite for the box representing total storage space
-
-	storage_start.overlays.Cut()
 
 	var/matrix/M = matrix()
 	M.Scale((storage_width-storage_cap_width*2+3)/32,1)
@@ -226,9 +257,20 @@
 		stored_start.transform = M_start
 		stored_continue.transform = M_continue
 		stored_end.transform = M_end
-		storage_start.overlays += stored_start
-		storage_start.overlays += stored_continue
-		storage_start.overlays += stored_end
+
+		var/obj/screen/storage/container = new()
+		container.screen_loc = "4:16,2:16"
+		container.icon_state = "blank"
+		container.layer = HUD_CLICKABLE_LAYER
+
+		container.overlays += stored_start
+		container.overlays += stored_continue
+		container.overlays += stored_end
+
+		container.SetName(O.name)
+		container.master = O
+
+		containers += container
 
 		O.screen_loc = "4:[round((startpoint+endpoint)/2)+2],2:16"
 		O.maptext = ""


### PR DESCRIPTION
## About The Pull Request

A batch of minor fixes to fix two major anti-QoL issues; items rendering behind storage blocks, and the storage blocks not being clickable.

## Why It's Good For The Game

Makes the game less painful to play

## Changelog
```changelog
add: Items can now be clicked on and picked up via their container blocks from storage, pixel-hunting is no longer necessary.
fix: Fixed items rendering behind storage blocks in variable width storages (backpacks, etc.)
```
