### PR TITLE
Pop-up turret respect small-sized crewmen more

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -511,13 +511,12 @@ var/list/turret_icons
 	if(iscuffed(L)) // If the target is handcuffed, leave it alone
 		return TURRET_NOT_TARGET
 
-	if(isanimal(L) || issmall(L)) // Animals are not so dangerous
-		return check_anomalies ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
-
-	if(isxenomorph(L) || isalien(L)) // Xenos are dangerous
-		return check_anomalies ? TURRET_PRIORITY_TARGET	: TURRET_NOT_TARGET
-
-	if(ishuman(L))	//if the target is a human, analyze threat level
+	if(!ishuman(L)) // Animals are not so dangerous
+		if(isxenomorph(L) || isalien(L)) // Xenos are dangerous
+			return check_anomalies ? TURRET_PRIORITY_TARGET	: TURRET_NOT_TARGET
+		else
+			return check_anomalies ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
+	else
 		if(assess_perp(L) < 4)
 			return TURRET_NOT_TARGET	//if threat level < 4, keep going
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -528,9 +528,6 @@ proc/is_blind(A)
 		if(istype(belt, /obj/item/weapon/gun) || istype(belt, /obj/item/weapon/melee))
 			threatcount += 2
 
-		if(species.name != SPECIES_HUMAN)
-			threatcount += 2
-
 	if(check_records || check_arrest)
 		var/perpname = name
 		if(id)


### PR DESCRIPTION
## About The Pull Request

A PR to remove hint of xenophobia from the code and turrets targeting small-sized humans for no reason.

## Why It's Good For The Game

Makes it more playable on Pluto for non-human crewmen.

## Changelog
```changelog
fix: Turrets no longer target crewmen that are smaller than human (specially Teshari)
```