### PR TITLE
Fix incorrect typepath for overmap generator

### DIFF
--- a/code/modules/overmap/generators/random.dm
+++ b/code/modules/overmap/generators/random.dm
@@ -56,7 +56,7 @@
 		if(T in candidate_turfs)
 			return T
 
-/datum/overmap_generator/system/place_overmap_item(obj/O)
+/datum/overmap_generator/random/place_overmap_item(obj/O)
 	if(empty_map_tiles.len)
 		var/turf/T = pick(empty_map_tiles)
 		. = place_overmap_item_at_turf(O, T)


### PR DESCRIPTION
## About The Pull Request

Fixes a miss where a proc was defined for `system` instead of `random`. Thank you, quardbreak @ Discord for pointing this out.

## Why It's Good For The Game

Does not affect the game directly. But the codebase should uphold a minimum quality and consistency as possible.

## Changelog
```changelog
fix: Fixed an incorrect typepath affecting how the overmap generators place events
```
