### PR TITLE
Fix plane settings on overmap objects

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -79,4 +79,8 @@
 	. = ..()
 	if(known)
 		layer = ABOVE_LIGHTING_LAYER
-		plane = EMISSIVE_PLANE
+		add_overlay(list(mutable_appearance(
+			icon,
+			icon_state,
+			plane = get_float_plane(EMISSIVE_PLANE)
+		)))

--- a/code/modules/overmap/star.dm
+++ b/code/modules/overmap/star.dm
@@ -45,7 +45,7 @@ var/list/star_classes = list(
 	icon = 'icons/obj/overmap.dmi'
 	icon_state = "event"
 	opacity = 1
-	plane = EMISSIVE_PLANE
+	plane = EFFECTS_BELOW_LIGHTING_PLANE
 
 /obj/effect/overmap_static/star
 	name = "Star"
@@ -66,3 +66,9 @@ var/list/star_classes = list(
 	transform = transform.Scale(2)
 	pixel_x = 1
 	pixel_y = -1
+
+	add_overlay(list(mutable_appearance(
+		icon,
+		icon_state,
+		plane = get_float_plane(EMISSIVE_PLANE)
+	)))


### PR DESCRIPTION
## About The Pull Request

After I fucked around with the emissives, I did not think much about the overmap objects. Turns out I should have. So this PR will amend to that.

## Why It's Good For The Game

Makes the game playable.

## Changelog
```changelog
fix: Fixed overmap objects whose location are known not showing up
fix: Fixed star not showing up.
```
