### PR TITLE
Emissive quick-fixes

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -13,7 +13,6 @@
 	var/on = 0
 	var/area/connected_area = null
 	var/other_area = null
-	var/image/overlay
 
 /obj/machinery/light_switch/Initialize()
 	. = ..()
@@ -29,19 +28,14 @@
 	update_icon()
 
 /obj/machinery/light_switch/update_icon()
-	if(!overlay)
-		overlay = image(icon, "light1-overlay")
-		overlay.plane = get_float_plane(EMISSIVE_PLANE)
-		overlay.layer = ABOVE_LIGHTING_LAYER
-
-	overlays.Cut()
+	cut_overlays()
 	if(stat & (NOPOWER|BROKEN))
 		icon_state = "light-p"
 		set_light(0)
 	else
 		icon_state = "light[on]"
-		overlay.icon_state = "light[on]-overlay"
-		overlays += overlay
+		add_overlay(get_emissive_blocker())
+		add_overlay(get_emissive_overlay(state = "light[on]-overlay"))
 		set_light(0.1, 0.1, 1, 2, on ? "#82ff4c" : "#f86060")
 
 /obj/machinery/light_switch/examine(mob/user)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -95,6 +95,7 @@
 	name = "machinery"
 	icon = 'icons/obj/stationobjs.dmi'
 	w_class = ITEM_SIZE_NO_CONTAINER
+	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 
 	var/stat = 0
 	var/emagged = 0

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/obj/structures.dmi'
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER
+	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 	var/health = 100
 	var/breakable
 	var/parts


### PR DESCRIPTION
## About The Pull Request

* Adds blocking of emissives for `obj/structure`
* Adds blocking of emissives for `obj/machinery`
* Fixes the emissive not working on lighting switches

But this does not fix the most glaring issue of entire of this codebase; the way `update_icon` works here.

## Why It's Good For The Game

Makes the graphics less jarring in general.

## Changelog
```changelog
fix: Fixed emissives showing through machinery
fix: Fixed emissives showing through structures
fix: Fixed lighting switches not showing through darkness properly
```
