### PR TITLE
Fix camera console not cleaning up proper

### DIFF
--- a/code/modules/modular_computers/ui_modules/camera_monitor.dm
+++ b/code/modules/modular_computers/ui_modules/camera_monitor.dm
@@ -102,7 +102,7 @@
 	. = ..()
 	selected_cameras = null
 	last_camera_turf = null
-	QDEL_NULL_ASSOC_LIST(camera_map_views)
+	QDEL_NULL_ASSOC_VAL_LIST(camera_map_views)
 	QDEL_NULL_LIST(camera_foregrounds)
 	QDEL_NULL_LIST(camera_skyboxes)
 


### PR DESCRIPTION
This fixes an runtime in qdel

## Changelog
```changelog
fix: Fixed the camera console not cleaning up properly
```