### PR TITLE
Better Power Cell PSUs; tgUI & material costs

### DIFF
--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -210,35 +210,64 @@
 		ui.open()
 
 /obj/machinery/power/smes/batteryrack/ui_data(mob/user)
-	var/data[0]
+	var/N = length(internal_cells)
+	. = list()
 
-	data["mode"] = mode
-	data["transfer_max"] = max_transfer_rate
-	data["output_load"] = round(output_used)
-	data["input_load"] = round(input_available)
-	data["equalise"] = equalise
-	data["blink_tick"] = ui_tick
-	data["cells_max"] = max_cells
-	data["cells_cur"] = internal_cells.len
-	var/list/cells = list()
-	var/cell_index = 0
-	for(var/obj/item/weapon/cell/C in internal_cells)
-		var/list/cell[0]
-		cell["slot"] = cell_index + 1
-		cell["used"] = 1
-		cell["percentage"] = round(C.percent(), 0.01)
-		cell["id"] = C.c_uid
-		cell_index++
-		cells += list(cell)
-	while(cell_index < PSU_MAXCELLS)
-		var/list/cell[0]
-		cell["slot"] = cell_index + 1
-		cell["used"] = 0
-		cell_index++
-		cells += list(cell)
-	data["cells_list"] = cells
+	.["mode"] = mode
+	.["transfer_max"] = max_transfer_rate
+	.["output_load"] = round(output_used)
+	.["input_load"] = round(input_available)
+	.["equalise"] = equalise
+	.["blink_tick"] = ui_tick
 
-	return data
+	.["cells_max"] = max_cells
+	.["cells_cur"] = N
+	.["cells"] = list()
+	for(var/cell_index in (1 to PSU_MAXCELLS))
+		if (cell_index <= N)
+			var/obj/item/weapon/cell/C = internal_cells[cell_index]
+			.["cells"] += list(list(
+				"slot" = cell_index,
+				"used" = TRUE,
+				"percentage" = round(C.percent(), 0.01),
+				"id" = C.c_uid,
+			))
+		else
+			.["cells"] += list(list(
+				"slot" = cell_index,
+				"used" = FALSE
+			))
+
+/obj/machinery/power/smes/batteryrack/ui_act(action, list/params)
+	switch(action)
+		if("disable")
+			update_io(0)
+			return TRUE
+		if("enable")
+			update_io(between(1, text2num(param["mode"]), 3))
+			return TRUE
+		if("equaliseon")
+			equalise = 1
+			return TRUE
+		if("equaliseoff")
+			equalise = 0
+			return TRUE
+		if("ejectcell")
+			var/obj/item/weapon/cell/C
+			for(var/obj/item/weapon/cell/CL in internal_cells)
+				if(CL.c_uid == text2num(params["eject"]))
+					C = CL
+					break
+
+			if(!istype(C))
+				return TRUE
+
+			C.forceMove(get_turf(src))
+			internal_cells -= C
+			update_icon()
+			RefreshParts()
+			update_maxcharge()
+			return TRUE
 
 /obj/machinery/power/smes/batteryrack/dismantle()
 	for(var/obj/item/weapon/cell/C in internal_cells)
@@ -259,49 +288,8 @@
 		else
 			to_chat(user, "\The [src] has no empty slot for \the [W]")
 
-/obj/machinery/power/smes/batteryrack/attack_hand(var/mob/user)
-	ui_interact(user)
-
 /obj/machinery/power/smes/batteryrack/inputting()
 	return
 
 /obj/machinery/power/smes/batteryrack/outputting()
 	return
-
-/obj/machinery/power/smes/batteryrack/Topic(href, href_list)
-	// ..() would respond to those topic calls, but we don't want to use them at all.
-	// Calls to these shouldn't occur anyway, due to usage of different nanoUI, but
-	// it's here in case someone decides to try hrefhacking/modified templates.
-	if(href_list["input"] || href_list["output"])
-		return 1
-
-	if(..())
-		return 1
-	if( href_list["disable"] )
-		update_io(0)
-		return 1
-	else if( href_list["enable"] )
-		update_io(between(1, text2num(href_list["enable"]), 3))
-		return 1
-	else if( href_list["equaliseon"] )
-		equalise = 1
-		return 1
-	else if( href_list["equaliseoff"] )
-		equalise = 0
-		return 1
-	else if( href_list["ejectcell"] )
-		var/obj/item/weapon/cell/C
-		for(var/obj/item/weapon/cell/CL in internal_cells)
-			if(CL.c_uid == text2num(href_list["ejectcell"]))
-				C = CL
-				break
-
-		if(!istype(C))
-			return 1
-
-		C.forceMove(get_turf(src))
-		internal_cells -= C
-		update_icon()
-		RefreshParts()
-		update_maxcharge()
-		return 1

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -19,7 +19,7 @@
 	var/max_transfer_rate = 0							// Maximal input/output rate. Determined by used capacitors when building the device.
 	var/mode = PSU_OFFLINE								// Current inputting/outputting mode
 	var/list/internal_cells = list()					// Cells stored in this PSU
-	var/max_cells = 3									// Maximal amount of stored cells at once. Capped at 9.
+	var/max_cells = PSU_MAXCELLS						// Maximal amount of stored cells at once. Capped at 9.
 	var/previous_charge = 0								// Charge previous tick.
 	var/equalise = 0									// If true try to equalise charge between cells
 	var/icon_update = 0									// Timer in ticks for icon update.
@@ -37,8 +37,6 @@
 	component_parts += new /obj/item/weapon/stock_parts/capacitor/				// Capacitors: Maximal I/O
 	component_parts += new /obj/item/weapon/stock_parts/capacitor/
 	component_parts += new /obj/item/weapon/stock_parts/capacitor/
-	component_parts += new /obj/item/weapon/stock_parts/matter_bin/				// Matter Bin: Max. amount of cells.
-
 
 /obj/machinery/power/smes/batteryrack/RefreshParts()
 	var/capacitor_efficiency = 0
@@ -46,11 +44,7 @@
 	for(var/obj/item/weapon/stock_parts/capacitor/CP in component_parts)
 		capacitor_efficiency += CP.rating
 
-	for(var/obj/item/weapon/stock_parts/matter_bin/MB in component_parts)
-		maxcells += MB.rating * 3
-
 	max_transfer_rate = 10000 * capacitor_efficiency // 30kw - 90kw depending on used capacitors.
-	max_cells = min(PSU_MAXCELLS, maxcells)
 	input_level = max_transfer_rate
 	output_level = max_transfer_rate
 
@@ -210,7 +204,6 @@
 		ui.open()
 
 /obj/machinery/power/smes/batteryrack/ui_data(mob/user)
-	var/N = length(internal_cells)
 	. = list()
 
 	.["mode"] = mode
@@ -220,16 +213,15 @@
 	.["equalise"] = equalise
 	.["blink_tick"] = ui_tick
 
-	.["cells_max"] = max_cells
-	.["cells_cur"] = N
 	.["cells"] = list()
-	for(var/cell_index in 1 to PSU_MAXCELLS)
-		if (cell_index <= N)
+	for(var/cell_index in 1 to max_cells)
+		if (cell_index <= length(internal_cells))
 			var/obj/item/weapon/cell/C = internal_cells[cell_index]
 			.["cells"] += list(list(
 				"slot" = cell_index,
 				"used" = TRUE,
-				"percentage" = round(C.percent(), 0.01),
+				"charge" = C.charge,
+				"capacity" = C.maxcharge,
 				"id" = C.c_uid,
 			))
 		else

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -206,7 +206,7 @@
 /obj/machinery/power/smes/batteryrack/ui_interact(mob/user, var/datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
-		ui = new(user, src, "PowerBatteryRack")
+		ui = new(user, src, "power/PowerBatteryRack", src.name)
 		ui.open()
 
 /obj/machinery/power/smes/batteryrack/ui_data(mob/user)
@@ -223,7 +223,7 @@
 	.["cells_max"] = max_cells
 	.["cells_cur"] = N
 	.["cells"] = list()
-	for(var/cell_index in (1 to PSU_MAXCELLS))
+	for(var/cell_index in 1 to PSU_MAXCELLS)
 		if (cell_index <= N)
 			var/obj/item/weapon/cell/C = internal_cells[cell_index]
 			.["cells"] += list(list(
@@ -244,13 +244,10 @@
 			update_io(0)
 			return TRUE
 		if("enable")
-			update_io(between(1, text2num(param["mode"]), 3))
+			update_io(between(1, text2num(params["mode"]), 3))
 			return TRUE
-		if("equaliseon")
-			equalise = 1
-			return TRUE
-		if("equaliseoff")
-			equalise = 0
+		if("equalise")
+			equalise = !equalise
 			return TRUE
 		if("ejectcell")
 			var/obj/item/weapon/cell/C

--- a/tgui/packages/tgui/components/Knob.js
+++ b/tgui/packages/tgui/components/Knob.js
@@ -37,6 +37,7 @@ export const Knob = props => {
     style,
     fillValue,
     color,
+    displayPos = "top",
     ranges = {},
     size = 1,
     bipolar,
@@ -109,7 +110,7 @@ export const Knob = props => {
               </div>
             </div>
             {dragging && (
-              <div className="Knob__popupValue">
+              <div className={`Knob__popupValue ${displayPos}`}>
                 {displayElement}
               </div>
             )}

--- a/tgui/packages/tgui/interfaces/power/PowerBatteryRack.js
+++ b/tgui/packages/tgui/interfaces/power/PowerBatteryRack.js
@@ -15,16 +15,20 @@ export const PowerBatteryRack = (props, context) => {
   } = data;
   const MODES = [
     "Offline",
-    "Input only",
     "Output only",
+    "Input only",
     "Automatic",
   ];
   return (
-    <Window>
+    <Window
+      width={400}
+      height={400}
+    >
       <Section>
         <LabeledControls>
           <LabeledControls.Item label="Input">
             <ProgressBar
+              width={9}
               value={input_load}
               maxValue={transfer_max}
             >
@@ -33,20 +37,25 @@ export const PowerBatteryRack = (props, context) => {
           </LabeledControls.Item>
           <LabeledControls.Item label="Output">
             <ProgressBar
+              width={9}
               value={output_load}
               maxValue={transfer_max}
             >
               {formatSiUnit(output_load, 0, "W")}
             </ProgressBar>
           </LabeledControls.Item>
-          <LabeledControls.Item label="Mode">
+          <LabeledControls.Item label="Mode" width={5}>
             {MODES[mode]}
           </LabeledControls.Item>
           <LabeledControls.Item label="Control">
             <Knob
               animated
+              value={mode}
               minValue={0}
               maxValue={3}
+              displayPos="left"
+              step={1}
+              stepPixelSize={25}
               format={(v) => `${v} (${MODES[v]})`}
               onChange={(e, v) => {
                 if (v) act("enable", { mode: v });
@@ -66,28 +75,34 @@ export const PowerBatteryRack = (props, context) => {
           />
         )}
       >
-        <table>
+        <table width="100%">
           <tr>
             <th>#</th>
-            <th>Charge</th>
+            <th width={300}>Charge</th>
             <th>Action</th>
           </tr>
           {cells.map((cell) => (
-            <tr key={cell.slot}>
+            <tr key={cell.slot} style={{ "line-height": "1.8em" }}>
               <td>{cell.slot}</td>
               <td>{cell.used && (
-                <ProgressBar />
+                <ProgressBar
+                  value={cell.charge}
+                  maxValue={cell.capacity}
+                >
+                  {formatSiUnit(cell.charge, 0, "W")} / {
+                    formatSiUnit(cell.capacity, 0, "W")
+                  }
+                </ProgressBar>
               ) || (
-                <Box italic>Empty</Box>
+                <Box textAlign="center" italic>Empty</Box>
               )}
               </td>
-              <td>{cell.used && (
+              <td>{!!cell.used && (
                 <Button
+                  fluid
+                  icon="sign-out-alt"
                   content="Eject"
-                />
-              ) || (
-                <Button
-                  content="Insert"
+                  onClick={() => act("ejectcell", { eject: cell.id })}
                 />
               )}
               </td>

--- a/tgui/packages/tgui/interfaces/power/PowerBatteryRack.js
+++ b/tgui/packages/tgui/interfaces/power/PowerBatteryRack.js
@@ -1,0 +1,100 @@
+import { useBackend } from "tgui/backend";
+import { Box, Button, Knob, LabeledControls, ProgressBar, Section } from "tgui/components";
+import { formatSiUnit } from "tgui/format";
+import { Window } from "tgui/layouts";
+
+export const PowerBatteryRack = (props, context) => {
+  const { data, act } = useBackend(context);
+  const {
+    mode,
+    cells,
+    equalise,
+    input_load,
+    output_load,
+    transfer_max,
+  } = data;
+  const MODES = [
+    "Offline",
+    "Input only",
+    "Output only",
+    "Automatic",
+  ];
+  return (
+    <Window>
+      <Section>
+        <LabeledControls>
+          <LabeledControls.Item label="Input">
+            <ProgressBar
+              value={input_load}
+              maxValue={transfer_max}
+            >
+              {formatSiUnit(input_load, 0, "W")}
+            </ProgressBar>
+          </LabeledControls.Item>
+          <LabeledControls.Item label="Output">
+            <ProgressBar
+              value={output_load}
+              maxValue={transfer_max}
+            >
+              {formatSiUnit(output_load, 0, "W")}
+            </ProgressBar>
+          </LabeledControls.Item>
+          <LabeledControls.Item label="Mode">
+            {MODES[mode]}
+          </LabeledControls.Item>
+          <LabeledControls.Item label="Control">
+            <Knob
+              animated
+              minValue={0}
+              maxValue={3}
+              format={(v) => `${v} (${MODES[v]})`}
+              onChange={(e, v) => {
+                if (v) act("enable", { mode: v });
+                else act("disable");
+              }}
+            />
+          </LabeledControls.Item>
+        </LabeledControls>
+      </Section>
+      <Section
+        title="Cells"
+        buttons={(
+          <Button.Checkbox
+            content="Equalise"
+            checked={!!equalise}
+            onClick={() => act("equalise")}
+          />
+        )}
+      >
+        <table>
+          <tr>
+            <th>#</th>
+            <th>Charge</th>
+            <th>Action</th>
+          </tr>
+          {cells.map((cell) => (
+            <tr key={cell.slot}>
+              <td>{cell.slot}</td>
+              <td>{cell.used && (
+                <ProgressBar />
+              ) || (
+                <Box italic>Empty</Box>
+              )}
+              </td>
+              <td>{cell.used && (
+                <Button
+                  content="Eject"
+                />
+              ) || (
+                <Button
+                  content="Insert"
+                />
+              )}
+              </td>
+            </tr>
+          ))}
+        </table>
+      </Section>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/styles/components/Knob.scss
+++ b/tgui/packages/tgui/styles/components/Knob.scss
@@ -68,8 +68,6 @@ $inner-padding: 0.1em;
 
 .Knob__popupValue {
   position: absolute;
-  top: -2rem;
-  right: 50%;
   font-size: 1rem;
   text-align: center;
   padding: 0.25rem 0.5rem;
@@ -77,6 +75,28 @@ $inner-padding: 0.1em;
   background-color: $popup-background-color;
   transform: translateX(50%);
   white-space: nowrap;
+
+  &.top {
+    top: -2rem;
+    right: 50%;
+  }
+
+  &.left {
+    top: 0.5rem;
+    left: -0.5rem;
+    transform: translateX(-100%);
+  }
+
+  &.right {
+    top: 0.5rem;
+    right: -0.5rem;
+    transform: translateX(100%);
+  }
+
+  &.bottom {
+    top: 2.5rem;
+    right: 50%;
+  }
 }
 
 .Knob__ring {


### PR DESCRIPTION
## About The Pull Request

Finally adds the missing tgUI for the power cell rack PSU. It looks like this:

![image](https://user-images.githubusercontent.com/13331724/143701923-490c2aa9-d343-4f9d-ab38-eb46783b3310.png)

Also, they don't require matter bins anymore. Instead, all the 9 slots will be available from start.

- Fixes #124

## Changelog
```changelog
add: Added tgUI interface for the Power Cell Rack PSU
tweak: Power Cell PSUs no longer require matter bins and always will have capacity for 9 cells.
tweak: Added property to Knob component in tgUI for positioning the tooltip appearing when dragging the knob
fix: Fixed the missing interface for tgUI
```
