### PR TITLE
Unit-test elevator consistency

### DIFF
--- a/code/modules/turbolift/_turbolift.dm
+++ b/code/modules/turbolift/_turbolift.dm
@@ -9,4 +9,4 @@
  * bunch of ChangeTurf() calls.
  */
 
-var/list/turbolifts = list()
+var/list/datum/turbolift/turbolifts = list()

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -14,6 +14,17 @@
 	var/busy_state                                      // Used for controller processing.
 	var/next_process
 
+	var/creator_type
+
+/datum/turbolift/New(creator_type)
+	src.creator_type = creator_type
+	turbolifts += src
+	. = ..()
+
+/datum/turbolift/Del()
+	turbolifts -= src
+	. = ..()
+
 /datum/turbolift/proc/emergency_stop()
 	queued_floors.Cut()
 	target_floor = null

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -21,7 +21,7 @@
 	turbolifts += src
 	. = ..()
 
-/datum/turbolift/Del()
+/datum/turbolift/Destroy()
 	turbolifts -= src
 	. = ..()
 

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -1,4 +1,7 @@
 // Used for creating the exchange areas.
+
+/var/list/area/turbolift_areas = list()
+
 /area/turbolift
 	name = "Turbolift"
 	base_turf = /turf/simulated/open
@@ -9,3 +12,9 @@
 	var/lift_floor_name = null
 	var/lift_announce_str = "Ding!"
 	var/arrival_sound = 'resources/sound/machines/ding.ogg'
+
+/area/turbolift/New()
+	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
+	if (!(src.type in turbolift_areas))
+		turbolift_areas[src.type] = list(x,y,z)

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -17,18 +17,10 @@
 
 	var/list/areas_to_use = list()
 
-/obj/turbolift_map_holder/Destroy()
-	turbolifts -= src
-	return ..()
-
-/obj/turbolift_map_holder/New()
-	turbolifts += src
-	..()
-
 /obj/turbolift_map_holder/Initialize()
 	. = ..()
 	// Create our system controller.
-	var/datum/turbolift/lift = new()
+	var/datum/turbolift/lift = new(src.type)
 
 	var/make_walls = !isnull(wall_type)
 	var/make_lights = !isnull(light_type)
@@ -250,18 +242,10 @@
 	var/floor_type = /turf/simulated/floor/tiled/dark
 	var/list/areas_to_use = list()
 
-/obj/freight_elevator_map_holder/Destroy()
-	turbolifts -= src
-	return ..()
-
-/obj/freight_elevator_map_holder/New()
-	turbolifts += src
-	..()
-
 /obj/freight_elevator_map_holder/Initialize()
 	. = ..()
 	// Create our system controller.
-	var/datum/turbolift/lift = new()
+	var/datum/turbolift/lift = new(src.type)
 
 	// Holder values since we're moving this object to null ASAP.
 	var/ux = x

--- a/code/unit_tests/_unit_tests.dm
+++ b/code/unit_tests/_unit_tests.dm
@@ -17,6 +17,7 @@
 #include "map_tests.dm"
 #include "mob_tests.dm"
 #include "movement_tests.dm"
+#include "multiz_tests.dm"
 #include "music_test.dm"
 #include "observation_tests.dm"
 #include "organ_tests.dm"

--- a/code/unit_tests/multiz_tests.dm
+++ b/code/unit_tests/multiz_tests.dm
@@ -19,6 +19,14 @@
 				failed[lift.creator_type] = TRUE
 				continue
 
+			var/list/coords = turbolift_areas[A.type]
+			var/sane = A.x == coords[1] && A.y == coords[2] && A.z == coords[3]
+			if(!sane)
+				log_bad("Lift [lift.creator_type]: Area [A] for Option [i] ([floor.label] - [floor.name]) is insane - located wrong or wrongly used in a map!")
+				failures += 1
+				failed[lift.creator_type] = TRUE
+				continue
+
 			var/consistent = (\
 				A.lift_floor_label == floor.label\
 				&& (A.lift_floor_name == floor.name || A.name == floor.name)\

--- a/code/unit_tests/multiz_tests.dm
+++ b/code/unit_tests/multiz_tests.dm
@@ -12,7 +12,13 @@
 	for (var/datum/turbolift/lift in turbolifts)
 		for (var/i in 1 to length(lift.floors))
 			var/datum/turbolift_floor/floor = lift.floors[i]
-			var/area/turbolift/A = floor.area_ref
+			var/area/turbolift/A = locate(floor.area_ref)
+			if (!A)
+				log_bad("Lift [lift.creator_type]: Could not locate the area for Option [i] ([floor.label] - [floor.name])!")
+				failures += 1
+				failed[lift.creator_type] = TRUE
+				continue
+
 			var/consistent = (\
 				A.lift_floor_label == floor.label\
 				&& (A.lift_floor_name == floor.name || A.name == floor.name)\

--- a/code/unit_tests/multiz_tests.dm
+++ b/code/unit_tests/multiz_tests.dm
@@ -1,0 +1,30 @@
+
+/datum/unit_test/elevator_floors_sanity/
+	name = "MULTI-Z: Elevators must be consistent & sane"
+
+/datum/unit_test/elevator_floors_sanity/start_test()
+	if(!length(turbolifts))
+		return 0
+
+	var/failures = 0
+	var/list/failed = list()
+
+	for (var/datum/turbolift/lift in turbolifts)
+		for (var/i in 1 to length(lift.floors))
+			var/datum/turbolift_floor/floor = lift.floors[i]
+			var/area/turbolift/A = floor.area_ref
+			var/consistent = (\
+				A.lift_floor_label == floor.label\
+				&& (A.lift_floor_name == floor.name || A.name == floor.name)\
+				&& A.lift_announce_str == floor.announce_str\
+			)
+			if(!consistent)
+				log_bad("Lift [lift.creator_type]: Option [i] ([floor.label] - [floor.name]) is inconsistent with [A]!")
+				failures += 1
+				failed[lift.creator_type] = TRUE
+
+	if(failures)
+		fail("Found [failures] inconsistencies in [english_list(failed)]!")
+	else
+		pass("All elevators found to be consistent & sane")
+	return 1

--- a/resources/Haven/Maps/TycloPluto/shuttles/elevator_main_define.dm
+++ b/resources/Haven/Maps/TycloPluto/shuttles/elevator_main_define.dm
@@ -39,7 +39,7 @@
 	wall_type = null
 
 	areas_to_use = list(
-		/area/turbolift/pluto/first_deck,
+		/area/turbolift/pluto/third_deck,
 		/area/turbolift/pluto/second_deck,
-		/area/turbolift/pluto/third_deck
+		/area/turbolift/pluto/first_deck,
 	)


### PR DESCRIPTION
## About The Pull Request

- Fixes #137 
- Aims at catch inconsistencies between lifts' data and the real world in the game
- Basically ensures that the lift options are ordered as they should

## Changelog
```changelog
tweak: Elevators are now unit-tested
fix: Fixed improper consistency with the world in elevator panels
```
