### PR TITLE
Turn compiler warnings into CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
-          tools/build/build
+          tools/build/build -Werror
 
   maps:
     name: Unit-Test

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -40,7 +40,6 @@
 
 /obj/machinery/power/smes/batteryrack/RefreshParts()
 	var/capacitor_efficiency = 0
-	var/maxcells = 0
 	for(var/obj/item/weapon/stock_parts/capacitor/CP in component_parts)
 		capacitor_efficiency += CP.rating
 


### PR DESCRIPTION
## About The Pull Request

Sometimes warnings slip through and are often not caught by either SpacemanDMM or the CI. So I made it so that compiler warnings get caught by the `Test Compile` task. The map-tests use their own log-checker that check for errors and warnings.

## Changelog
```changelog
```
