### PR TITLE
Fix AI being unable to interact with anything

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/ui.dm
+++ b/code/modules/modular_computers/computers/modular_computer/ui.dm
@@ -1,5 +1,5 @@
 /obj/item/modular_computer/ui_state(mob/user)
-	return ui_physical_state()
+	return ui_default_state()
 
 /obj/item/modular_computer/ui_status(mob/user, datum/ui_state/state)
 	if(!screen_on || !enabled || bsod)

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -42,7 +42,7 @@ GLOBAL_DATUM_INIT(default_state, /datum/ui_state/default, new)
 		return
 
 	// The AI can interact with anything it can see nearby, or with cameras while wireless control is enabled.
-	if(!control_disabled && can_see(src_object))
+	if(!control_disabled && can_see(src, src_object))
 		return UI_INTERACTIVE
 	return UI_CLOSE
 

--- a/resources/maps/example/example-1.dmm
+++ b/resources/maps/example/example-1.dmm
@@ -272,6 +272,10 @@
 /obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/tiled,
 /area/constructionsite)
+"zU" = (
+/mob/living/silicon/ai,
+/turf/simulated/floor/tiled,
+/area/constructionsite)
 "Gx" = (
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled,
@@ -999,7 +1003,7 @@ al
 al
 ac
 ac
-ac
+zU
 ac
 ac
 at

--- a/resources/maps/example/example-1.dmm
+++ b/resources/maps/example/example-1.dmm
@@ -273,7 +273,7 @@
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "zU" = (
-/mob/living/silicon/ai,
+/obj/structure/AIcore/deactivated,
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "Gx" = (


### PR DESCRIPTION
## About The Pull Request

- Fixes #142

The error was caused by a wrongly used `can_see` proc. It was used with `can_see(target)`, but expected `can_see(source, target)`, and requires two positionals. The one-positional use should have NEVER gone through, this error never was caught by the compiler or the CI for some fucking reason.

Fucking amazing.

## Changelog
```changelog
tweak: Modular computers' UI-state changed from physical-only to default
fix: Fixed AI being unable to interact with all physical objects that can be accessible by the AI:
```
