### PR TITLE
Minor multi-z optimization

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -1003,8 +1003,6 @@
 			return global.worths;
 		if("wrapped_species_by_ref")
 			return global.wrapped_species_by_ref;
-		if("z_levels")
-			return global.z_levels;
 		if("zone_blocked")
 			return global.zone_blocked;
 
@@ -2012,8 +2010,6 @@
 			global.worths=newval;
 		if("wrapped_species_by_ref")
 			global.wrapped_species_by_ref=newval;
-		if("z_levels")
-			global.z_levels=newval;
 		if("zone_blocked")
 			global.zone_blocked=newval;
 
@@ -2519,6 +2515,5 @@
 	"world_uplinks",
 	"worths",
 	"wrapped_species_by_ref",
-	"z_levels",
 	"zone_blocked"
 )

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -16,7 +16,7 @@
 		src.render_target = "[initial(src.render_target)]-[z_level]z"
 	else
 		src.render_target = "[src.plane]-[z_level]z"
-	src.plane = calculate_plane(z_level, src.plane)
+	src.plane = calculate_plane_by_depth(z_level - 1, src.plane)
 
 /atom/movable/screen/plane_master/proc/Show(override)
 	alpha = override || show_alpha
@@ -35,7 +35,7 @@
  *
  *  For multi_z rendering, take a look in _onclick/hud/hud.dm and _onclick/hud/map_view.dm
  *  For a list of what planes are included, take a look in
- *  __defines/_planes+layers.dm
+ *  __defines/_layering.dm
  */
 
 #define EMISSIVE_RENDER_TARGET "*emissive_render_target"

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -1,6 +1,3 @@
-// If you add a more comprehensive system, just untick this file.
-var/list/z_levels = list()// Each bit re... haha just kidding this is a list of bools now
-
 // If the height is more than 1, we mark all contained levels as connected.
 /obj/effect/landmark/map_data/New()
 	..()
@@ -9,10 +6,6 @@ var/list/z_levels = list()// Each bit re... haha just kidding this is a list of 
 	var/obj/effect/landmark/submap_data/current
 
 	for(var/i = (z - height + 1) to (z))
-		if (z_levels.len <i)
-			z_levels.len = i
-		z_levels[i] = TRUE
-
 		// Generate submap chunks
 		current = new/obj/effect/landmark/submap_data(locate(1,1,i))
 		if (previous)
@@ -35,14 +28,14 @@ var/list/z_levels = list()// Each bit re... haha just kidding this is a list of 
 	return (z - bottom_z) + 1
 
 /proc/HasAbove(var/z)
-	if(z >= world.maxz || z < 1 || z > z_levels.len)
+	if(z >= world.maxz || z < 1)
 		return FALSE
 	if (HasSubmapData(z))
 		return GetSubmapData(z).has_above()
 	return FALSE
 
 /proc/HasBelow(var/z)
-	if(z > world.maxz || z < 2 || (z-1) > z_levels.len)
+	if(z > world.maxz || z < 2)
 		return FALSE
 	if (HasSubmapData(z))
 		return GetSubmapData(z).has_below()

--- a/code/modules/multiz/planes.dm
+++ b/code/modules/multiz/planes.dm
@@ -7,16 +7,19 @@
 	if(!original_plane)
 		original_plane = plane
 
-/atom/proc/set_plane(var/new_plane)	//Changes plane
+/atom/proc/set_plane(new_plane)	//Changes plane
 	original_plane = new_plane
 	update_plane()
 
-/proc/calculate_plane(var/z,var/original_plane)
-	if(z <= 0 || z_levels.len < z)
+/proc/calculate_plane(z, original_plane)
+	if(z <= 0 || z > world.maxz)
 		return original_plane
 
 	var/bottom_most_z = HasSubmapData(z) ? GetSubmapData(z).get_bottommost_z() : z
-	return min(MAX_PLANE,((z - bottom_most_z)*PLANES_PER_Z_LEVEL) + original_plane)
+	return calculate_plane_by_depth(z - bottom_most_z, original_plane)
+
+/proc/calculate_plane_by_depth(z_depth, original)
+	return min(MAX_PLANE,(max(0, z_depth)*PLANES_PER_Z_LEVEL) + original)
 
 /atom/proc/update_plane(override_z = 0)	//Updates plane using local z-coordinate
 	var/_z = (override_z || z)
@@ -27,10 +30,10 @@
 
 // Should be used for objects and base icons
 // For non-absolute or cached overlays, use get_float_plane
-/atom/proc/get_relative_plane(var/plane)
+/atom/proc/get_relative_plane(plane)
 	return calculate_plane(z,plane)
 
 // Should be used for overlays, specially cached ones
 // For atoms, use get_relative_plane
-/atom/proc/get_float_plane(var/plane)
+/atom/proc/get_float_plane(plane)
 	return FLOAT_PLANE + (plane - original_plane)


### PR DESCRIPTION
## About The Pull Request

I lied. It is actually a pretty minor bugfix that caused by some hell of a smell in the multi-z code I wrote when porting the feature from CEV-Eris. But all things considered, the changes makes away a plenty of calculation from some features.

## Changelog
```changelog
fix: Fixes the multi-z rendering issue, in which it would be permanently broken for a player the moment they enter a submap with incorrect Z ordering.
```
