### PR TITLE
Fix runtime error on `vis_locs` in View-Variables

### DIFF
--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -1,7 +1,18 @@
 // Variables not to expand the lists of. Vars is pointless to expand, and overlays/underlays cannot be expanded.
-/var/list/view_variables_dont_expand = list("overlays", "underlays", "vars")
+/var/list/view_variables_dont_expand = list(
+	"overlays",
+	"underlays",
+	"vars"
+)
 // Variables that runtime if you try to test associativity of the lists they contain by indexing
-/var/list/view_variables_no_assoc = list("verbs", "contents", "screen", "images", "vis_contents")
+/var/list/view_variables_no_assoc = list(
+	"contents",
+	"images",
+	"screen",
+	"verbs",
+	"vis_contents",
+	"vis_locs"
+)
 
 // Acceptable 'in world', as VV would be incredibly hampered otherwise
 /client/proc/debug_variables(datum/D in world)


### PR DESCRIPTION
## About The Pull Request

`vis_locs` is a list of atoms that has this atom in their `vis_contents` list. View-Variables tested it for associativity, which cause it to runtime and not show up properly.

## Changelog
```changelog
fix: Fixed a runtime error related to vis_locs when viewed in View-Variables debug tool
```
