### PR TITLE
Make Oxford Comma default for `english_list`

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -10,7 +10,7 @@
  */
 
 //Returns a list in plain english as a string
-/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
+/proc/english_list(list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = ",")
 	switch(input.len)
 		if(0) return nothing_text
 		if(1) return "[input[1]]"

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -190,7 +190,7 @@ GLOBAL_PROTECT(log_end)
 	if(dir & UP) comps += "UP"
 	if(dir & DOWN) comps += "DOWN"
 
-	return english_list(comps, nothing_text="0", and_text="|", comma_text="|")
+	return english_list(comps, "0", "|", "|", "")
 
 //more or less a logging utility
 /proc/key_name(var/whom, var/include_link = null, var/include_name = 1, var/highlight_special_characters = 1, var/datum/ticket/ticket = null)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -381,7 +381,7 @@
 				table += " [capitalize(get_wound_severity(E.burn_ratio))] burns ([E.burn_dam])"
 			if(E.brute_dam + E.burn_dam == 0)
 				table += "None"
-			table += "</td><td>[english_list(E.get_scan_results(), nothing_text = "", and_text = ", ")]</td></tr>"
+			table += "</td><td>[english_list(E.get_scan_results(), "", ", ", ", ", "")]</td></tr>"
 
 	table += "<tr><td>---</td><td><b>INTERNAL ORGANS</b></td><td>---</td></tr>"
 	for(var/obj/item/organ/internal/I in H.internal_organs)
@@ -395,7 +395,7 @@
 			table += "Minor"
 		else
 			table += "None"
-		table += "</td><td>[english_list(I.get_scan_results(), nothing_text = "", and_text = ", ")]</td></tr>"
+		table += "</td><td>[english_list(I.get_scan_results(), "", ", ", ", ", "")]</td></tr>"
 	table += "</table>"
 	dat += jointext(table,null)
 	table.Cut()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -195,7 +195,7 @@
 				assembly.dropInto(loc)
 				assembly.anchored = 1
 				assembly.camera_name = c_tag
-				assembly.camera_network = english_list(network, "Exodus", ",", ",")
+				assembly.camera_network = english_list(network, "Exodus", ",", ",", "")
 				assembly.update_icon()
 				assembly.dir = src.dir
 				if(stat & BROKEN)

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -170,7 +170,7 @@
 					for (var/A in accesses)
 						if (A in giver.access)
 							access_descriptors += get_access_desc(A)
-					entry += english_list(access_descriptors, and_text = ", ")
+					entry += english_list(access_descriptors, and_text = ", ", final_comma_text = "")
 					entry += ". Expires at [worldtime2stationtime(world.time + duration MINUTES)]."
 					internal_log.Add(entry)
 

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -111,7 +111,7 @@
 	..()
 
 /datum/gear_tweak/contents/get_contents(var/metadata)
-	return "Contents: [english_list(metadata, and_text = ", ")]"
+	return "Contents: [english_list(metadata)]"
 
 /datum/gear_tweak/contents/get_default()
 	. = list()
@@ -210,7 +210,7 @@
 	O = ValidTeslaLinks[metadata[7]]
 	if(O)
 		names += initial(O.name)
-	return "[english_list(names, and_text = ", ")]"
+	return "[english_list(names)]"
 
 /datum/gear_tweak/tablet/get_metadata(var/user, var/metadata, var/title)
 	. = list()

--- a/code/modules/modular_computers/ui_modules/alarm_monitor.dm
+++ b/code/modules/modular_computers/ui_modules/alarm_monitor.dm
@@ -96,7 +96,7 @@
 					"origin_lost" = A.origin == null,
 					"has_cameras" = cameras.len,
 					"cameras" = cameras,
-					"lost_sources" = lost_sources.len ? sanitize(english_list(lost_sources, nothing_text = "", and_text = ", ")) : ""))
+					"lost_sources" = lost_sources.len ? sanitize(english_list(lost_sources, "", ", ", ", ", "")) : ""))
 	data["categories"] = categories
 
 	return data

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -216,7 +216,7 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 	. = list()
 	for(var/datum/reagent/current in reagent_list)
 		. += "[current.name] ([current.volume])"
-	return english_list(., "EMPTY", "", ", ", ", ")
+	return english_list(., "EMPTY", ", ", ", ", "")
 
 /* Holder-to-holder and similar procs */
 


### PR DESCRIPTION
## About The Pull Request

- Makes the Oxford Comma the default for uses of `english_list`
- Alters some uses of `english_list`, for better or worse

## Changelog
```changelog
spellcheck: Oxford Comma is now default for text from `english_list`, expect to see them in plenty of places
```
