### PR TITLE
Fix improper `ui_act` usage

### DIFF
--- a/code/__defines/tgui.dm
+++ b/code/__defines/tgui.dm
@@ -33,3 +33,12 @@
 		"type" = type, \
 		"payload" = payload, \
 	))))
+
+/// Standard super() call to make sure that the ui_act is sane
+#define UI_ACT_CHECK \
+	if(..()) {return TRUE}
+
+/// Standard super() call to make sure that the ui_act is sane
+/// Except do not trigger the action in the overriden ui_act of parent
+#define UI_ACT_CHECK_NO_ACTION \
+	if(..(null, null)) {return TRUE}

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -646,6 +646,8 @@
 	return min(..(), .)
 
 /obj/machinery/alarm/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("rcon")
 			var/attempted_rcon_setting = text2num(params["rcon"])

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -192,6 +192,8 @@
 	return data
 
 /obj/machinery/computer/general_air_control/large_tank_control/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if ("out_set_value")
 			var/change = text2num(params["new_value"])
@@ -455,6 +457,8 @@ Rate: [volume_rate] L/sec<BR>"}
 	return data
 
 /obj/machinery/computer/general_air_control/fuel_injection/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch (action)
 		if ("refresh_status")
 			device_info = null

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -300,26 +300,25 @@ update_flag
 		ui.open()
 
 /obj/machinery/portable_atmospherics/canister/ui_data(mob/user)
-	// this is the data which will be sent to the ui
-	var/data[0]
-	data["name"] = name
-	data["canLabel"] = can_label ? 1 : 0
-	data["portConnected"] = connected_port ? 1 : 0
-	data["pressure"] = round(air_contents.return_pressure() || 0)
-	data["releasePressure"] = round(release_pressure || 0)
-	data["minReleasePressure"] = round(ONE_ATMOSPHERE/10)
-	data["maxReleasePressure"] = round(10*ONE_ATMOSPHERE)
-	data["defaultReleasePressure"] = round(initial(release_pressure))
-	data["valveOpen"] = valve_open ? 1 : 0
+	. = ..()
+	.["name"] = name
+	.["canLabel"] = can_label ? 1 : 0
+	.["portConnected"] = connected_port ? 1 : 0
+	.["pressure"] = round(air_contents.return_pressure() || 0)
+	.["releasePressure"] = round(release_pressure || 0)
+	.["minReleasePressure"] = round(ONE_ATMOSPHERE/10)
+	.["maxReleasePressure"] = round(10*ONE_ATMOSPHERE)
+	.["defaultReleasePressure"] = round(initial(release_pressure))
+	.["valveOpen"] = valve_open ? 1 : 0
 
-	data["holdingTank"] = holding ? list(
+	.["holdingTank"] = holding ? list(
 		"name" = holding.name,
 		"pressure" = round(holding.air_contents.return_pressure())
 	) : null
 
-	return data
-
 /obj/machinery/portable_atmospherics/canister/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("valve")
 			if (valve_open)
@@ -370,7 +369,7 @@ update_flag
 			if(.)
 				release_pressure = clamp(round(pressure), min_release_pressure, max_release_pressure)
 				//investigate_log("was set to [release_pressure] kPa by [key_name(usr)].", INVESTIGATE_ATMOS)
-			return . // This will always return 'null' if . is not included
+			return .
 
 		if ("relabel")
 			if (!can_label)

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -146,6 +146,8 @@
 	return data
 
 /obj/machinery/portable_atmospherics/powered/pump/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if ("power")
 			on = !on

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -131,6 +131,8 @@
 	return data
 
 /obj/machinery/portable_atmospherics/powered/scrubber/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("power")
 			on = !on

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -144,6 +144,8 @@
 	)
 
 /obj/machinery/biogenerator/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch (action)
 		if("activate")
 			activate()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -152,6 +152,8 @@
 	return data
 
 /obj/machinery/atmospherics/unary/cryo_cell/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("power")
 			on = !on

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -81,6 +81,8 @@
 	return data
 
 /obj/item/weapon/airlock_electronics/ui_act(action, params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("clear")
 			if(!locked)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -182,8 +182,7 @@
 
 
 /obj/machinery/door_timer/ui_act(action, params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	if(!src.allowed(usr))
 		return TRUE

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -105,6 +105,8 @@
 	)
 
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("command")
 			if(params["command"] in list(

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -48,6 +48,8 @@
 	)
 
 /obj/machinery/embedded_controller/radio/airlock/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("command")
 			if(params["command"] in list(

--- a/code/game/machinery/embedded_controller/airlock_docking_controller_multi.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller_multi.dm
@@ -79,6 +79,8 @@
 	)
 
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi/ui_act(action, list/params)
+	UI_ACT_CHECK_NO_ACTION
+
 	switch(action)
 		if("command")
 			if(params["command"] in list(

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -29,8 +29,7 @@
 	return data
 
 /obj/machinery/embedded_controller/radio/simple_docking_controller/ui_act(action, list/params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	switch(action)
 		if("command")

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -126,8 +126,7 @@
 	return data
 
 /obj/machinery/media/jukebox/ui_act(action, params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 	switch(action)
 		if("change_track")
 			for(var/datum/track/T in tracks)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -304,6 +304,8 @@
 	return data
 
 /obj/machinery/smartfridge/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("vend")
 			var/index = params["vend"]

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -217,8 +217,9 @@
 	. = ..()
 
 /obj/machinery/ui_act(action, list/params, datum/tgui/ui)
-	add_fingerprint(usr)
-	return ..()
+	if(usr && Adjacent(usr))
+		add_fingerprint(usr)
+	. = ..(action, params, ui)
 
 /obj/machinery/Topic(href, href_list)
 	..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -216,7 +216,7 @@
 	user.set_machine(src)
 	. = ..()
 
-/obj/machinery/ui_act(action, list/params)
+/obj/machinery/ui_act(action, list/params, datum/tgui/ui)
 	add_fingerprint(usr)
 	return ..()
 

--- a/code/game/machinery/resleever.dm
+++ b/code/game/machinery/resleever.dm
@@ -122,8 +122,7 @@
 	return data
 
 /obj/machinery/resleever/ui_act(action, params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 	switch(action)
 		if("begin")
 			sleeve()

--- a/code/game/machinery/sleeper.dm
+++ b/code/game/machinery/sleeper.dm
@@ -105,6 +105,8 @@
 	. = ..()
 
 /obj/machinery/sleeper/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("eject")
 			go_out()

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -140,6 +140,8 @@
 	return data
 
 /obj/machinery/turretid/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("command")
 			var/log_action = null

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -387,6 +387,8 @@
 	return data
 
 /obj/machinery/vending/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("remove_coin")
 			if(!istype(usr, /mob/living/silicon))

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -125,6 +125,8 @@
 	)
 
 /obj/machinery/mecha_part_fabricator/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if ("add_queue_part")
 			add_to_queue(params["id"])

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -115,6 +115,8 @@
 		ui.open()
 
 /obj/item/device/radio/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("frequency")
 			if (locked_frequency)

--- a/code/game/objects/items/devices/suit_sensor_jammer.dm
+++ b/code/game/objects/items/devices/suit_sensor_jammer.dm
@@ -144,8 +144,7 @@
 	return data
 
 /obj/item/device/suit_sensor_jammer/ui_act(action, params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 	switch(action)
 		if("enable_jammer")
 			enable()

--- a/code/game/objects/items/weapons/storage/storage_ui/tgui.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/tgui.dm
@@ -53,8 +53,7 @@
 	return cached_ui_data
 
 /datum/storage_ui/tgui/ui_act(action, params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	if(action == "remove_item")
 		var/item_type = locate(params["type"])

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -270,8 +270,7 @@ var/list/global/tank_gauge_cache = list()
 	return ui_inventory_state()
 
 /obj/item/weapon/tank/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 	switch(action)
 		if ("set_release")
 			switch(params["value"])

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -69,8 +69,7 @@
 	return ..()
 
 /obj/structure/undies_wardrobe/Topic(href, href_list, state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	var/mob/living/carbon/human/H = usr
 	if(href_list["select_underwear"])

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -207,6 +207,8 @@
 	)
 
 /obj/machinery/atmospherics/binary/passive_gate/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("toggle_valve")
 			unlocked = !unlocked

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -147,6 +147,8 @@ Thus, the two variables affect pump operation are set in New():
 	return data
 
 /obj/machinery/atmospherics/binary/pump/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("power")
 			use_power = !use_power

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -95,6 +95,8 @@
 	return data
 
 /obj/machinery/atmospherics/unary/freezer/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("toggleStatus")
 			use_power = !use_power

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -116,6 +116,8 @@
 	return data
 
 /obj/machinery/atmospherics/unary/heater/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("toggleStatus")
 			use_power = !use_power

--- a/code/modules/modular_computers/file_system/program_ui_module.dm
+++ b/code/modules/modular_computers/file_system/program_ui_module.dm
@@ -26,6 +26,7 @@
 		ui.open()
 
 /datum/ui_module/program/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	UI_ACT_CHECK
 	return program && program.ui_act(action, params, ui, state)
 
 /datum/computer_file/program/apply_visual(mob/M)

--- a/code/modules/modular_computers/ui_modules/camera_monitor.dm
+++ b/code/modules/modular_computers/ui_modules/camera_monitor.dm
@@ -190,8 +190,7 @@
 	return check_access(user, access_security) || check_access(user, network_access)
 
 /datum/ui_module/program/camera_monitor/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	switch(action)
 		if("switch_camera")

--- a/code/modules/modular_computers/ui_modules/comm.dm
+++ b/code/modules/modular_computers/ui_modules/comm.dm
@@ -106,8 +106,7 @@
 	return GLOB.global_message_listener
 
 /datum/ui_module/program/comm/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 	var/mob/user = usr
 	var/ntn_comm = program ? !!program.get_signal(NTNET_COMMUNICATION) : 1
 	var/ntn_cont = program ? !!program.get_signal(NTNET_SYSTEMCONTROL) : 1

--- a/code/modules/modular_computers/ui_modules/email_client.dm
+++ b/code/modules/modular_computers/ui_modules/email_client.dm
@@ -254,8 +254,7 @@
 
 
 /datum/ui_module/program/email_client/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 	var/mob/living/user = usr
 
 	check_for_new_messages(1)		// Any actual interaction (button pressing) is considered as acknowledging received message, for the purpose of notification icons.

--- a/code/modules/modular_computers/ui_modules/force_authorization.dm
+++ b/code/modules/modular_computers/ui_modules/force_authorization.dm
@@ -50,8 +50,7 @@
 	return data
 
 /datum/ui_module/program/forceauthorization/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	switch(action)
 		if("authorize")

--- a/code/modules/modular_computers/ui_modules/rcon.dm
+++ b/code/modules/modular_computers/ui_modules/rcon.dm
@@ -31,8 +31,7 @@
 	.["breakers"] = breakerlist
 
 /datum/ui_module/program/rcon/ui_act(action, list/params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	var/tag = params["tag"]
 	switch(action)

--- a/code/modules/modular_computers/ui_modules/records.dm
+++ b/code/modules/modular_computers/ui_modules/records.dm
@@ -67,8 +67,7 @@
 			return selection.img
 
 /datum/ui_module/program/records/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	switch(action)
 		if("open_record")

--- a/code/modules/modular_computers/ui_modules/shields_monitor.dm
+++ b/code/modules/modular_computers/ui_modules/shields_monitor.dm
@@ -43,11 +43,11 @@
 		shields_info.Add(temp)
 	.["shields"] = shields_info
 
-/datum/ui_module/program/shields_monitor/ui_act(action, list/params)
+/datum/ui_module/program/shields_monitor/ui_act(action, list/params, datum/tgui/ui)
 	UI_ACT_CHECK
 
 	// Unchecked and unvalidated ui interaction, weeeeeeeeee
-	if(active && active.ui_act(action, params))
+	if(active && active.ui_act(action, params, ui))
 		return TRUE
 
 	switch(action)

--- a/code/modules/modular_computers/ui_modules/shields_monitor.dm
+++ b/code/modules/modular_computers/ui_modules/shields_monitor.dm
@@ -44,8 +44,7 @@
 	.["shields"] = shields_info
 
 /datum/ui_module/program/shields_monitor/ui_act(action, list/params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	// Unchecked and unvalidated ui interaction, weeeeeeeeee
 	if(active && active.ui_act(action, params))

--- a/code/modules/modular_computers/ui_modules/supermatter_monitor.dm
+++ b/code/modules/modular_computers/ui_modules/supermatter_monitor.dm
@@ -83,8 +83,7 @@
 		.["supermatters"] = SMS
 
 /datum/ui_module/program/supermatter_monitor/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	switch(action)
 		if("clear_active")

--- a/code/modules/modular_computers/ui_modules/supply.dm
+++ b/code/modules/modular_computers/ui_modules/supply.dm
@@ -58,8 +58,7 @@
 	return data
 
 /datum/ui_module/program/supply/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	var/mob/living/user = usr
 	switch(action)

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -47,6 +47,8 @@
 	return data
 
 /obj/machinery/computer/ship/engines/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("global_set_state")
 			linked.engines_state = params["state"]

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -103,6 +103,8 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	)
 
 /obj/machinery/computer/ship/helm/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if ("move")
 			linked.relaymove(usr, params["move"])

--- a/code/modules/overmap/ships/computers/navigation.dm
+++ b/code/modules/overmap/ships/computers/navigation.dm
@@ -54,6 +54,8 @@
 	ui_interact(user)
 
 /obj/machinery/computer/ship/navigation/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("view")
 			viewing = !viewing

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -74,6 +74,8 @@
 	return data
 
 /obj/machinery/computer/ship/sensors/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("view")
 			viewing = !viewing

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -230,6 +230,8 @@
 			))
 
 /obj/machinery/power/smes/batteryrack/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("disable")
 			update_io(0)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -384,6 +384,8 @@
 	.["failureTimer"] = failure_timer * 2
 
 /obj/machinery/power/smes/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("try_input")
 			inputting(!input_attempt)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -141,6 +141,8 @@
 	return data
 
 /obj/machinery/chemical_dispenser/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("amount")
 			amount = round(text2num(params["amount"]), 1) // round to nearest 1

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -235,7 +235,7 @@
 		"offlineFor" = offline_for * 2
 	)
 
-/obj/machinery/power/shield_generator/ui_act(action, list/params)
+/obj/machinery/power/shield_generator/ui_act(action, list/params, datum/tgui/ui)
 	UI_ACT_CHECK
 
 	switch(action)

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -236,6 +236,8 @@
 	)
 
 /obj/machinery/power/shield_generator/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("begin_shutdown")
 			if(running != SHIELD_RUNNING)

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -97,6 +97,7 @@
 		ui.open()
 
 /obj/machinery/computer/shuttle_control/ui_act(action, list/params)
+	UI_ACT_CHECK
 	return handle_ui_act(SSshuttle.shuttles[shuttle_tag], action, params, usr)
 
 /obj/machinery/computer/shuttle_control/emag_act(var/remaining_charges, var/mob/user)

--- a/code/modules/structures/toolcarts/toolcart.dm
+++ b/code/modules/structures/toolcarts/toolcart.dm
@@ -68,6 +68,8 @@
 			))
 
 /obj/structure/tool_cart/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("take")
 			var/target = params["take"]

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -74,6 +74,7 @@
  * return bool If the user's input has been handled and the UI should update.
  */
 /datum/proc/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	SHOULD_CALL_PARENT(TRUE)
 	// If UI is not interactive or usr calling Topic is not the UI user, bail.
 	if(!ui || ui.status != UI_INTERACTIVE)
 		return TRUE

--- a/code/modules/ui_modules/appearance_changer.dm
+++ b/code/modules/ui_modules/appearance_changer.dm
@@ -19,8 +19,7 @@
 	src.blacklist = species_blacklist
 
 /datum/ui_module/appearance_changer/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	switch(action)
 		if("race")

--- a/code/modules/urist/modules/newtrading/NPC/npc_interact.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc_interact.dm
@@ -82,6 +82,8 @@
 	return data
 
 /mob/living/simple_animal/hostile/npc/ui_act(action, list/params, datum/tgui/ui)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("sell_item_l")
 			var/mob/living/carbon/M = locate(params["user"])

--- a/code/modules/urist/modules/shipbattles/combatcomputer.dm
+++ b/code/modules/urist/modules/shipbattles/combatcomputer.dm
@@ -89,8 +89,7 @@
 		.["target"] = null
 
 /obj/machinery/computer/combatcomputer/ui_act(action, list/params)
-	if(..())
-		return TRUE
+	UI_ACT_CHECK
 
 	switch(action)
 		if("fire")

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -94,6 +94,8 @@
 			isolate()
 
 /obj/machinery/disease2/centrifuge/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if("print")
 			print(usr)

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -92,6 +92,8 @@
 	)
 
 /obj/machinery/disease2/incubator/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if ("eject_chem")
 			if(beaker)

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -112,6 +112,8 @@
 			update_icon()
 
 /obj/machinery/disease2/isolator/ui_act(action, list/params)
+	UI_ACT_CHECK
+
 	switch(action)
 		if ("print")
 			print(usr, params["print"])


### PR DESCRIPTION
## About The Pull Request

- Fixes #165
- Adds `UI_ACT_CHECK` as a macro for `ui_act` to check for status and run parent's actions normally
- Adds `UI_ACT_CHECK_NO_ACTION`  as a macro for `ui_act` but without running through rest of the parent's ui_act if possible
- Adds `SHOULD_CALL_PARENT` to `ui_act`
- These should fix the server-side issue of the permission issues
- Additionally fix the issue where using the UI wouldn't leave fingerprints on the host object

## Changelog
```changelog
fix: Fixed permission check issues with UI where ghosts would be able to interact UI unrestricted
fix: Fixed users never leaving fingerprints on objects they interact with via UI due to improper use of the interaction proc
```
