### PR TITLE
Minor UI changes to portable generators

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -33,7 +33,6 @@
 	if(active && HasFuel() && !IsBroken() && anchored && powernet)
 		add_avail(power_gen * power_output)
 		UseFuel()
-		src.updateDialog()
 	else
 		active = 0
 		handleInactive()
@@ -234,7 +233,6 @@
 		var/temp_loss = (temperature - cooling_temperature)/TEMPERATURE_DIVISOR
 		temp_loss = between(2, round(temp_loss, 1), TEMPERATURE_CHANGE_MAX)
 		temperature = max(temperature - temp_loss, cooling_temperature)
-		src.updateDialog()
 
 	if(overheating)
 		overheating--
@@ -275,7 +273,6 @@
 		to_chat(user, "<span class='notice'>You add [amount] sheet\s to the [src.name].</span>")
 		sheets += amount
 		addstack.use(amount)
-		updateUsrDialog()
 		return
 	else if(!active)
 		if(isWrench(O))
@@ -306,9 +303,6 @@
 	..()
 	if (!anchored)
 		return
-	ui_interact(user)
-
-/obj/machinery/power/port_gen/pacman/attack_ai(mob/user as mob)
 	ui_interact(user)
 
 /obj/machinery/power/port_gen/pacman/ui_status(mob/user, datum/ui_state/state)


### PR DESCRIPTION
## About The Pull Request

- Fixes #207
- Fixes AI being able to interact with the portable generators' UI

## Changelog
```changelog
tweak: AIs can no longer interact with portable generators
fix: Fixed the Pacman generator reopening the UI when running
```
