### PR TITLE
Try-catch callbacks

### DIFF
--- a/code/___compile_options.dm
+++ b/code/___compile_options.dm
@@ -10,6 +10,12 @@
 // If you think you need more, rethink it
 #define MAX_ATOM_OVERLAYS 100
 
+// Toggle whether the Baystation's callbacks system shall be wrapped in a try-catch block,
+// to suppliment more debug information to the runtime messages.
+//		1 will enable this feature
+//		0 will disable this feature
+#define TRY_CATCH_CALLBACKS 1
+
 #ifdef CIBUILDING
 #define UNIT_TEST
 #endif
@@ -20,8 +26,11 @@
 #endif
 
 #if defined(UNIT_TESTS)
-//Hard del testing defines
+// Hard del testing defines
 #define FIND_REF_NO_CHECK_TICK
+
+// The callbacks system is wrapped in try-catch to suppliment more debug information to messages
+#define TRY_CATCH_CALLBACKS 1
 #endif
 
 #if !defined(CBT) && !defined(SPACEMAN_DMM)

--- a/code/__defines/callback.dm
+++ b/code/__defines/callback.dm
@@ -1,4 +1,7 @@
-#define GLOBAL_PROC	"some_magic_bullshit"
 
-#define CALLBACK new /datum/callback
+// Abitrary integer constant because fuck string comparison
+// Was previously a string constant; "some_magic_bullshit"
+#define GLOBAL_PROC	0xBEEF
+
+#define CALLBACK(arguments...) new /datum/callback(__FILE__, __LINE__, arguments)
 #define INVOKE_ASYNC ImmediateInvokeAsync

--- a/code/datums/callbacks.dm
+++ b/code/datums/callbacks.dm
@@ -6,12 +6,18 @@
 	var/delegate
 	var/list/arguments
 
-/datum/callback/New(thingtocall, proctocall, ...)
+	var/source_file
+	var/source_line
+
+/datum/callback/New(_file, _line, thingtocall, proctocall, ...)
+	source_file = _file
+	source_line = _line
+
 	if (thingtocall)
 		object = thingtocall
 	delegate = proctocall
-	if (length(args) > 2)
-		arguments = args.Copy(3)
+	if (length(args) > 4)
+		arguments = args.Copy(5)
 
 /proc/ImmediateInvokeAsync(thingtocall, proctocall, ...)
 	set waitfor = FALSE
@@ -26,18 +32,43 @@
 	else
 		call(thingtocall, proctocall)(arglist(calling_arguments))
 
+#if (TRY_CATCH_CALLBACKS)
+#define DO_INVOKE \
+	try { \
+		if (object == GLOBAL_PROC) { \
+			return call(delegate)(arglist(calling_arguments)); \
+		} \
+		return call(object, delegate)(arglist(calling_arguments)); \
+	} catch (var/exception/e) { \
+		var/file_name = splicetext(source_file, 1, findlasttext(source_file,"/") + 1); \
+		if (e.name == "bad proc") { \
+			if (object == GLOBAL_PROC) { CRASH("Invalid global delegate '[delegate]' given by [file_name],[source_line]"); } \
+			else { CRASH("Invalid type delegate '[delegate]' given by [file_name],[source_line]"); } \
+		} \
+		else { \
+			e.name = "\<\<Callback of [file_name],[source_line]\>\> [e.name]"; \
+			throw e; \
+		} \
+	}
+#else
+#define DO_INVOKE \
+	if (object == GLOBAL_PROC) { \
+		return call(delegate)(arglist(calling_arguments)); \
+	} \
+	return call(object, delegate)(arglist(calling_arguments));
+#endif
+
 /datum/callback/proc/Invoke(...)
 	if (!object)
 		return
 	var/list/calling_arguments = arguments
 	if (length(args))
 		if (length(arguments))
-			calling_arguments = calling_arguments + args //not += so that it creates a new list so the arguments list stays clean
+			//not += so that it creates a new list so the arguments list stays clean
+			calling_arguments = calling_arguments + args
 		else
 			calling_arguments = args
-	if (object == GLOBAL_PROC)
-		return call(delegate)(arglist(calling_arguments))
-	return call(object, delegate)(arglist(calling_arguments))
+	DO_INVOKE
 
 //copy and pasted because fuck proc overhead
 /datum/callback/proc/InvokeAsync(...)
@@ -47,9 +78,10 @@
 	var/list/calling_arguments = arguments
 	if (length(args))
 		if (length(arguments))
-			calling_arguments = calling_arguments + args //not += so that it creates a new list so the arguments list stays clean
+			//not += so that it creates a new list so the arguments list stays clean
+			calling_arguments = calling_arguments + args
 		else
 			calling_arguments = args
-	if (object == GLOBAL_PROC)
-		return call(delegate)(arglist(calling_arguments))
-	return call(object, delegate)(arglist(calling_arguments))
+	DO_INVOKE
+
+#undef DO_INVOKE


### PR DESCRIPTION
## About The Pull Request

Something that occurred to me when I was working on #230, yet I really wished I had much earlier to save me trouble. Originally I wrote it in #230, so I am making this PR to atomize the changes instead.

Don't you hate it when your log is full off runtimes like these?
```
[14:00:08] Runtime in unsorted.dm,1042: qdel() can only handle /datum (sub)types, was passed: "H"
  proc name: crash with (/proc/crash_with)
  src: null
  call stack:
  crash with("qdel() can only handle /datum ...")
  qdel("H", 0)
  /datum/callback (/datum/callback): InvokeAsync()
  Timer (/datum/controller/subsystem/timer): fire(0)
  Timer (/datum/controller/subsystem/timer): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)
```

Fret not buddy! I have got your back covered here! Here's a demonstration!

```
[19:00:19] Runtime in unsorted.dm,1042: <<Callback of temporary_effect.dm,14>> qdel() can only handle /datum (sub)types, was passed: "H"
  proc name: crash with (/proc/crash_with)
  src: null
  call stack:
  crash with("qdel() can only handle /datum ...")
  qdel("H", 0)
  /datum/callback (/datum/callback): InvokeAsync()
  Timer (/datum/controller/subsystem/timer): fire(0)
  Timer (/datum/controller/subsystem/timer): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)
```

However, one important head-note on this that the try-catch attempts to filter "bad proc" exceptions and change the message to a more helpful description. Which might be nice and all, but the filter does no distinction on who threw that exception or where it came from. So it will indiscriminately catch and replace any "bad proc" thrown in the function. 

The functionality needed to enhance the filter to catch just the exceptions thrown within `/datum/callback` is `__PROC__` and `__TYPE__`, features introduced in the beta version `515.1602`. We have to learn make do with what we have right now.
 
## Changelog
```changelog
tweak: Added an opt-in feature to wrap callbacks in try-catch for enhanced error-reporting information
```
